### PR TITLE
[refactor] 상담 일지에서 api 호출하는 방식 수정

### DIFF
--- a/src/api/analysis/analysisQuery.js
+++ b/src/api/analysis/analysisQuery.js
@@ -1,0 +1,9 @@
+import axios from '../config/axios';
+
+/**
+ * 분석 기록 조회
+ * @param {string} counselId
+ */
+export const getAnalysisResult = (counselId) => {
+    return axios.get(`/api/v1/analysis/${counselId}/analysis`);
+};

--- a/src/views/CounselingReport.vue
+++ b/src/views/CounselingReport.vue
@@ -77,7 +77,9 @@
 <script setup>
 import { ref, computed, onMounted, nextTick } from 'vue';
 import { useRoute } from 'vue-router';
-import axios from 'axios';
+
+import { fetchCounselById } from '@/api/counsel/counselQuery';
+import { getAnalysisResult } from '@/api/analysis/analysisQuery'
 
 import SideBar from '@/components/common/SideBar.vue';
 import TroubleSummary from '@/components/analysis/TroubleSummary.vue';
@@ -123,7 +125,7 @@ const toggleExpand = () => {
 
 const fetchAnalysisData = async () => {
     try {
-        const response = await axios.get(`http://localhost:8080/api/v1/analysis/${counselId}/analysis`);
+        const response = await getAnalysisResult(counselId);
         data.value = response.data;
     } catch (error) {
         console.error('Failed to fetch analysis data', error);
@@ -132,7 +134,7 @@ const fetchAnalysisData = async () => {
 
 const fetchCounselContent = async () => {
     try {
-        const response = await axios.get(`http://localhost:8080/api/v1/counsels/${counselId}`);
+        const response = await fetchCounselById(counselId);
         counselContent.value = response.data.content;
     } catch (error) {
         console.error('Failed to fetch counsel content', error);


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [X] 리팩토링
- [ ] 버그 픽스

### 🔀 작업 브랜치
refactor/sh/analysis_switch_api_

### #️⃣ 연관된 이슈
close #22 


### 📝 변경 사항
- 상담 내용 조회 api 경로 수정(localhost:8080 -> api 쓰는 방식)
- 분석 내용 조회 api 경로 수정
